### PR TITLE
Triming trailing spaces at the end of the testcases names

### DIFF
--- a/src/main/java/com/microfocus/application/automation/tools/results/service/almentities/AlmTestImpl.java
+++ b/src/main/java/com/microfocus/application/automation/tools/results/service/almentities/AlmTestImpl.java
@@ -29,7 +29,10 @@
 package com.microfocus.application.automation.tools.results.service.almentities;
 
 public class AlmTestImpl extends AlmEntityImpl implements AlmTest {
-	private static String restPrefix = "tests"; 
+	private static String restPrefix = "tests";
+	private String trimTrailingSpace(String s){
+		return s.replaceFirst("\\s++$", "");
+	}
 	public String getRestPrefix() {
 		return restPrefix;
 	}
@@ -37,7 +40,7 @@ public class AlmTestImpl extends AlmEntityImpl implements AlmTest {
 	public String getKey(){
 		String className = (String)getFieldValue(TS_UT_CLASS_NAME);
 		
-		String methodName = (String)getFieldValue(TS_UT_METHOD_NAME);
+		String methodName = trimTrailingSpace((String)getFieldValue(TS_UT_METHOD_NAME));
 		String packageName = (String)getFieldValue(TS_UT_PACKAGE_NAME);
 		if(packageName == null) {
 			packageName = "";


### PR DESCRIPTION
Hi,
It is necessary to trim the trailing spaces at the end of the testcases names, otherwise in the second run of a report it would be considred a new testcase.
Making the ALM server dening it for duplicate testcase.
N.B : The spaces are correctly removed in the POST request sent to the server.

Jira issue : https://issues.jenkins.io/browse/JENKINS-65390